### PR TITLE
Setup project to work with the Unity Package Manager.

### DIFF
--- a/Assets/HSVPicker/Editor/HSVPicker.Editor.asmdef
+++ b/Assets/HSVPicker/Editor/HSVPicker.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "HSVPicker.Editor",
+    "references": [
+        "HSVPicker"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Assets/HSVPicker/Editor/HSVPicker.Editor.asmdef.meta
+++ b/Assets/HSVPicker/Editor/HSVPicker.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 485edc8694d264a8fb6d3a830531425d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HSVPicker/HSVPicker.asmdef
+++ b/Assets/HSVPicker/HSVPicker.asmdef
@@ -1,0 +1,3 @@
+﻿{
+	"name": "HSVPicker"
+}

--- a/Assets/HSVPicker/HSVPicker.asmdef.meta
+++ b/Assets/HSVPicker/HSVPicker.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 413a95a52ca644b7dac76988ad8915af
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HSVPicker/package.json
+++ b/Assets/HSVPicker/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "judah4.hsvcolorpickerunity",
+    "displayName": "HSVPicker",
+    "version": "2.2.1",
+    "unity": "2019.1",
+    "description": "HSV color picker for Unity UI",
+    "keywords": [
+    ],
+    "dependencies": {
+    }
+}

--- a/Assets/HSVPicker/package.json.meta
+++ b/Assets/HSVPicker/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d46aec3749789425caab28d9edf026cf
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+deploy:
+	git subtree push --prefix Assets/HSVPicker origin upm
+
+deploy-force:
+	git push origin `git subtree split --prefix Assets/HSVPicker master`:upm --force

--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@ Unity 2017
 Unity 5.6  
 2019 is default, 2018 can import the assets just fine.  2017 and Unity 5 versions are on older branches.
 
+## Install
+
+### UPM
+
+```json
+{
+  "dependencies": {
+    "judah4.hsvcolorpickerunity": "https://github.com/judah4/HSV-Color-Picker-Unity.git#upm",
+    ...
+  }
+}
+```
+
+### Unity Package
+
+<https://github.com/judah4/HSV-Color-Picker-Unity/releases>
+
 ![alt tag](https://i.imgur.com/Fn2T6Nu.png)
 Should be really easy to use. Just add the prefab to the canvas, hook up an event, and it's good to go.
 ```csharp


### PR DESCRIPTION
First of all, thank you for releasing this project! Unity desperately needs more advanced options for user input, and this fits the bill quite nicely.

As for this PR, I've put together a few necessary files that allow this project to be installed via the Unity Package Manager.

A few resources on Unity Package Manager:
1. https://docs.unity3d.com/Manual/Packages.html
1. https://neogeek.dev/creating-custom-packages-for-unity-2018.3/

Some files to note:
1. `Makefile` - this file is used to push the `Assets/HSVPicker` directory to a git branch named `upm`. `upm` is the branch that will be installed via the Unity Package Manager.
1. `package.json` - this file is used to tell Unity that this repo supports the Unity Package Manager.

Let me know if you have any questions about this PR.

Thanks again!