### PR TITLE
Unsubscribe to events in ColorPresets class in OnDestroy method

### DIFF
--- a/Assets/HSVPicker/UI/ColorPresets.cs
+++ b/Assets/HSVPicker/UI/ColorPresets.cs
@@ -82,5 +82,11 @@ namespace HSVPicker
 	    {
 		    createPresetImage.color = color;
 	    }
+
+        private void OnDestroy()
+        {
+            picker.onValueChanged.RemoveListener(ColorChanged);
+            _colors.OnColorsUpdated -= OnColorsUpdate;
+        }
     }
 }


### PR DESCRIPTION
When ColorPicker prefab is destroyed and then instantiated, ColorPicker events remain being called on destroyed components, raising exceptions in unity.
By unsubscribing to the events when component is destroyed, exceptions are avoided.