### PR TITLE
Move RegenerateSVTexture() in SVBoxSlider to OnEnable rather than Awa…

### DIFF
--- a/Assets/HSVPicker/UI/SVBoxSlider.cs
+++ b/Assets/HSVPicker/UI/SVBoxSlider.cs
@@ -33,10 +33,6 @@ namespace HSVPicker
         {
             slider = GetComponent<BoxSlider>();
             image = GetComponent<RawImage>();
-            if(Application.isPlaying)
-            {
-                RegenerateSVTexture ();
-            }
         }
 
         private void OnEnable()
@@ -45,6 +41,11 @@ namespace HSVPicker
             {
                 slider.onValueChanged.AddListener(SliderChanged);
                 picker.onHSVChanged.AddListener(HSVChanged);
+            }
+
+            if (Application.isPlaying)
+            {
+                RegenerateSVTexture();
             }
         }
 


### PR DESCRIPTION
…ke, which resolves an issue with the colour box gradient not regenerating if re-using the colour picker for another value.

This is a minor change which fixes an issue I noticed when re-using a single instance of a colour picker, where I was using it to set multiple user-selectable colour values, one at a time. When a new colour was assigned by script, the colour slider values were correct, but the colour box was still incorrect until a change was made, at which point it regenerated. This PR should resolve that issue.