### PR TITLE
Add null validation of Setup.SliderToggleButtonText

### DIFF
--- a/Assets/HSVPicker/UI/ColorPicker.cs
+++ b/Assets/HSVPicker/UI/ColorPicker.cs
@@ -293,6 +293,11 @@ namespace HSVPicker
 
         void UpdateColorToggleText()
         {
+            if (Setup.SliderToggleButtonText == null)
+            {
+                return;
+            }
+            
             if (Setup.ShowRgb)
             {
                 Setup.SliderToggleButtonText.text = "RGB";


### PR DESCRIPTION
Hi, I'm using HSV-Color-Picker-Unity in my project and this is very useful for me.

However, I tried not setting `Setup.SliderToggleButtonText` because I use only HSV sliders, not RGB sliders, but Unity gave me the following error message.

<img width="620" alt="image" src="https://user-images.githubusercontent.com/4960850/159114744-4acb7071-5aa1-4c66-8300-7f873af6637f.png">

So I added a null validation to `void UpdateColorToggleText()`.

Thanks.