### PR TITLE
Update ColorSliderImage.cs, avoid error log on DestroyImmediate

### DIFF
--- a/Packages/com.judahperez.hsvcolorpicker/UI/ColorSliderImage.cs
+++ b/Packages/com.judahperez.hsvcolorpicker/UI/ColorSliderImage.cs
@@ -15,6 +15,7 @@ namespace HSVPicker
         public Slider.Direction direction;
 
         private RawImage image;
+        private Texture initialTexture;
 
         private RectTransform rectTransform
         {
@@ -27,6 +28,7 @@ namespace HSVPicker
         private void Awake()
         {
             image = GetComponent<RawImage>();
+            initialTexture = image.texture;
 
             if(Application.isPlaying)
                 RegenerateTexture();
@@ -52,7 +54,7 @@ namespace HSVPicker
 
         private void OnDestroy()
         {
-            if (image.texture != null)
+            if (image.texture != null && image.texture != initialTexture)
                 DestroyImmediate(image.texture);
         }
 
@@ -184,7 +186,7 @@ namespace HSVPicker
             texture.SetPixels32(colors);
             texture.Apply();
 
-            if (image.texture != null)
+            if (image.texture != null && image.texture != initialTexture)
                 DestroyImmediate(image.texture);
             image.texture = texture;
 


### PR DESCRIPTION
# About

This fixes this error log which appears at start playing on Unity Editor. When using ColorSliderImage and link an asset as the RawImage's texture.

```
Destroying assets is not permitted to avoid data loss.
If you really want to remove an asset use DestroyImmediate (theObject, true);
 #0 GetStacktrace(int)
 #1 DebugStringToFile(DebugStringToFileData const&)
 #2 Scripting::DestroyObjectFromScriptingImmediate(Object*, bool, ScriptingExceptionPtr*)
 #3 Object_CUSTOM_DestroyImmediate(ScriptingBackendNativeObjectPtrOpaque*, unsigned char)
 #4  (Mono JIT Code) (wrapper managed-to-native) UnityEngine.Object:DestroyImmediate (UnityEngine.Object,bool)
 #5  (Mono JIT Code) [UnityEngineObject.bindings.cs:435] UnityEngine.Object:DestroyImmediate (UnityEngine.Object)
 #6  (Mono JIT Code) [ColorSliderImage.cs:189] HSVPicker.ColorSliderImage:RegenerateTexture ()
 #7  (Mono JIT Code) [ColorSliderImage.cs:33] HSVPicker.ColorSliderImage:Awake ()
```

# Details

Original code wants to destroy the linked asset, which means destroying the asset files.
So I added a condition to destroy so that it doesn't destroy original linked asset.

# Environment

Unity 2022.3.24f1
