### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ https://openupm.com/packages/com.judahperez.hsvcolorpicker/
         {
             "name": "package.openupm.com",
             "url": "https://package.openupm.com",
-            "scopes": []
+            "scopes": [
+                "com.judahperez"
+            ]
         }
     ],
     "dependencies": {


### PR DESCRIPTION
Unity doesn't allow "scopes" to be empty